### PR TITLE
start chores from default branch

### DIFF
--- a/internal/entrypoints/finalisechore.go
+++ b/internal/entrypoints/finalisechore.go
@@ -41,7 +41,7 @@ func FinaliseChore() {
 
 	changedSincePreviousRuns, err := git.WorkBranchDiffersFromFinalBranch(job)
 	if err != nil {
-		l.Error("Error moving changes to final branch", "error", err)
+		l.Error("Error comparing work and final branches", "error", err)
 		os.Exit(1)
 	}
 

--- a/internal/entrypoints/finalisechore.go
+++ b/internal/entrypoints/finalisechore.go
@@ -39,13 +39,13 @@ func FinaliseChore() {
 		return
 	}
 
-	changedSinceLastRun, err := git.TmpBranchHasChanges(job)
+	changedSincePreviousRuns, err := git.TmpBranchDiffersFromFinalBranch(job)
 	if err != nil {
 		l.Error("Error moving changes to final branch", "error", err)
 		os.Exit(1)
 	}
 
-	if !changedSinceLastRun {
+	if !changedSincePreviousRuns {
 		l.Info("Identical changes have already been pushed, no need to overwrite them")
 		os.Exit(0)
 		return

--- a/internal/entrypoints/finalisechore.go
+++ b/internal/entrypoints/finalisechore.go
@@ -39,7 +39,7 @@ func FinaliseChore() {
 		return
 	}
 
-	changedSincePreviousRuns, err := git.TmpBranchDiffersFromFinalBranch(job)
+	changedSincePreviousRuns, err := git.WorkBranchDiffersFromFinalBranch(job)
 	if err != nil {
 		l.Error("Error moving changes to final branch", "error", err)
 		os.Exit(1)
@@ -51,7 +51,7 @@ func FinaliseChore() {
 		return
 	}
 
-	err = git.Push(job)
+	err = git.PushWorkBranchToFinalBranch(job)
 	if err != nil {
 		l.Error("Error pushing changes", "error", err)
 		os.Exit(1)

--- a/internal/entrypoints/initchore.go
+++ b/internal/entrypoints/initchore.go
@@ -14,13 +14,13 @@ func InitChore() {
 		os.Exit(1)
 	}
 
-	err = git.CloneRepo(job.Repo, job.Config)
+	err = git.CloneRepo(job, job.Config)
 	if err != nil {
 		l.Error("Error cloning repo", "error", err)
 		os.Exit(1)
 	}
 
-	err = git.CheckoutBranchForJob(job)
+	err = git.CheckoutBranch(job, job.TmpBranchName)
 	if err != nil {
 		l.Error("Error checking out branch for chore", "error", err)
 		os.Exit(1)

--- a/internal/entrypoints/initchore.go
+++ b/internal/entrypoints/initchore.go
@@ -20,7 +20,7 @@ func InitChore() {
 		os.Exit(1)
 	}
 
-	err = git.CheckoutBranch(job, job.TmpBranchName)
+	err = git.CheckoutBranch(job, job.WorkBranchName)
 	if err != nil {
 		l.Error("Error checking out branch for chore", "error", err)
 		os.Exit(1)

--- a/internal/entrypoints/initchore.go
+++ b/internal/entrypoints/initchore.go
@@ -20,7 +20,7 @@ func InitChore() {
 		os.Exit(1)
 	}
 
-	err = git.CheckoutBranch(job, job.WorkBranchName)
+	err = git.CheckoutWorkBranch(job)
 	if err != nil {
 		l.Error("Error checking out branch for chore", "error", err)
 		os.Exit(1)

--- a/internal/entrypoints/run.go
+++ b/internal/entrypoints/run.go
@@ -141,12 +141,15 @@ func gatherJobs(conf *schema.TediumConfig) *utils.Queue[schema.Job] {
 			l.Info("Resolved chores for repo", "repo", targetRepo.FullName(), "chores", len(repoConfig.Chores))
 
 			for choreIdx := range repoConfig.Chores {
+				chore := repoConfig.Chores[choreIdx]
 				jobQueue.Push(schema.Job{
-					Config:         conf,
-					Repo:           targetRepo,
-					RepoConfig:     repoConfig,
-					Chore:          repoConfig.Chores[choreIdx],
-					PlatformConfig: platformConfig,
+					Config:          conf,
+					Repo:            targetRepo,
+					RepoConfig:      repoConfig,
+					Chore:           chore,
+					PlatformConfig:  platformConfig,
+					TmpBranchName:   utils.UniqueName("tmp"),
+					FinalBranchName: utils.ConvertToBranchName(chore.Name),
 				})
 			}
 		}

--- a/internal/entrypoints/run.go
+++ b/internal/entrypoints/run.go
@@ -148,7 +148,7 @@ func gatherJobs(conf *schema.TediumConfig) *utils.Queue[schema.Job] {
 					RepoConfig:      repoConfig,
 					Chore:           chore,
 					PlatformConfig:  platformConfig,
-					TmpBranchName:   utils.UniqueName("tmp"),
+					WorkBranchName:  utils.UniqueName("work"),
 					FinalBranchName: utils.ConvertToBranchName(chore.Name),
 				})
 			}

--- a/internal/executors/kubernetes/pods.go
+++ b/internal/executors/kubernetes/pods.go
@@ -22,7 +22,7 @@ func (executor *KubernetesExecutor) getContainerStatus(podName string, container
 }
 
 func (executor *KubernetesExecutor) waitForContainerCompletion(podName string, containerIdx int) error {
-	return wait.PollUntilContextTimeout(k8sExecutorContext, 1*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(k8sExecutorContext, 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		status, err := executor.getContainerStatus(podName, containerIdx)
 		if err != nil {
 			return false, fmt.Errorf("Error getting container status to check completion: %w", err)

--- a/internal/executors/podman/podman.go
+++ b/internal/executors/podman/podman.go
@@ -65,8 +65,8 @@ func (p *PodmanExecutor) Init(conf *schema.TediumConfig) error {
 
 func (p *PodmanExecutor) Deinit() error {
 	time.Sleep(5 * time.Second)
-	p.cleanUpContainers()
-	p.cleanUpVolumes()
+	// p.cleanUpContainers()
+	// p.cleanUpVolumes()
 
 	return nil
 }

--- a/internal/executors/podman/podman.go
+++ b/internal/executors/podman/podman.go
@@ -65,8 +65,8 @@ func (p *PodmanExecutor) Init(conf *schema.TediumConfig) error {
 
 func (p *PodmanExecutor) Deinit() error {
 	time.Sleep(5 * time.Second)
-	// p.cleanUpContainers()
-	// p.cleanUpVolumes()
+	p.cleanUpContainers()
+	p.cleanUpVolumes()
 
 	return nil
 }

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -122,7 +122,7 @@ func CommitIfChanged(job *schema.Job, profile *schema.PlatformProfile) (bool, er
 	return true, nil
 }
 
-func TmpBranchHasChanges(job *schema.Job) (bool, error) {
+func TmpBranchDiffersFromFinalBranch(job *schema.Job) (bool, error) {
 	realRepo, _, err := openRepo(job.Repo)
 	if err != nil {
 		return false, err

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -45,12 +45,8 @@ func CloneRepo(job *schema.Job, conf *schema.TediumConfig) error {
 	return nil
 }
 
-// CheckoutBranch checks out a branch in a repo, creating it if necessary
-func CheckoutBranch(job *schema.Job, branchName string) error {
-	branchRefName := plumbing.NewBranchReferenceName(branchName)
-
-	l.Info("Checking out a branch for chore", "branch", branchName)
-
+// CheckoutWorkBranch checks out the work branch in a repo, creating it if necessary.
+func CheckoutWorkBranch(job *schema.Job) error {
 	realRepo, worktree, err := openRepo(job.Repo)
 	if err != nil {
 		return err
@@ -65,21 +61,20 @@ func CheckoutBranch(job *schema.Job, branchName string) error {
 		return fmt.Errorf("Refusing to checkout a new branch on an unclean repo")
 	}
 
-	branchExists, err := branchExists(realRepo, branchName)
+	branchExists, err := branchExists(realRepo, job.WorkBranchName)
 	if err != nil {
 		return fmt.Errorf("error checking whether chore branch already exists: %w", err)
 	}
 
-	if !branchExists {
-		l.Info("Branch does not exist - it will be created", "branch", branchName)
-	}
+	l.Info("Checking out work branch for chore", "branch", job.WorkBranchName, "created", !branchExists)
 
+	branchRefName := plumbing.NewBranchReferenceName(job.WorkBranchName)
 	err = worktree.Checkout(&git.CheckoutOptions{
 		Branch: branchRefName,
 		Create: !branchExists,
 	})
 	if err != nil {
-		return fmt.Errorf("error checking out chore branch: %w", err)
+		return fmt.Errorf("error checking out work branch: %w", err)
 	}
 
 	return nil

--- a/internal/git/repo.go
+++ b/internal/git/repo.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/markormesher/tedium/internal/logging"
 	"github.com/markormesher/tedium/internal/schema"
-	"github.com/markormesher/tedium/internal/utils"
 )
 
 var l = logging.Logger
@@ -20,7 +19,9 @@ var l = logging.Logger
 // repos are only ever cloned inside an execution container, so this path doesn't change per-repo
 var repoClonePath = "/tedium/repo"
 
-func CloneRepo(repo *schema.Repo, conf *schema.TediumConfig) error {
+func CloneRepo(job *schema.Job, conf *schema.TediumConfig) error {
+	repo := job.Repo
+
 	l.Info("Cloning repo", "url", repo.CloneUrl)
 
 	err := os.MkdirAll(repoClonePath, os.ModePerm)
@@ -28,7 +29,7 @@ func CloneRepo(repo *schema.Repo, conf *schema.TediumConfig) error {
 		return fmt.Errorf("Error creating repo storage: %v", err)
 	}
 
-	realRepo, err := git.PlainClone(repoClonePath, false, &git.CloneOptions{
+	_, err = git.PlainClone(repoClonePath, false, &git.CloneOptions{
 		URL:  repo.CloneUrl,
 		Auth: repo.Auth.ToTransportAuth(),
 	})
@@ -41,14 +42,11 @@ func CloneRepo(repo *schema.Repo, conf *schema.TediumConfig) error {
 		return fmt.Errorf("Error running fetch: %w", err)
 	}
 
-	reportRepoState(realRepo, "clone: after")
-
 	return nil
 }
 
-// CheckoutBranchForJob checks out a named branch on a repo, creating it if necessary.
-func CheckoutBranchForJob(job *schema.Job) error {
-	branchName := utils.ConvertToBranchName(job.Chore.Name)
+// CheckoutBranch checks out a branch in a repo, creating it if necessary
+func CheckoutBranch(job *schema.Job, branchName string) error {
 	branchRefName := plumbing.NewBranchReferenceName(branchName)
 
 	l.Info("Checking out a branch for chore", "branch", branchName)
@@ -58,7 +56,7 @@ func CheckoutBranchForJob(job *schema.Job) error {
 		return err
 	}
 
-	// sanity check: the repo should be in a clean state, otherwise something else is misbehaving; if it is not, bail out to avoid making things worse
+	// sanity check: the repo should be in a clean state
 	status, err := worktree.Status()
 	if err != nil {
 		return fmt.Errorf("Error checking repo status: %w", err)
@@ -67,22 +65,9 @@ func CheckoutBranchForJob(job *schema.Job) error {
 		return fmt.Errorf("Refusing to checkout a new branch on an unclean repo")
 	}
 
-	reportRepoState(realRepo, "chore branch: before")
-
-	// iterate branches to check whether we have one already (checking via .Branch(name string) doesn't reliably work)
-	branchExists := false
-	branches, err := realRepo.Branches()
+	branchExists, err := branchExists(realRepo, branchName)
 	if err != nil {
-		return fmt.Errorf("Error listing repo branches: %w", err)
-	}
-	err = branches.ForEach(func(ref *plumbing.Reference) error {
-		if ref.Name() == branchRefName {
-			branchExists = true
-		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("Error checking whether chore branch already exists: %w", err)
+		return fmt.Errorf("error checking whether chore branch already exists: %w", err)
 	}
 
 	if !branchExists {
@@ -94,16 +79,14 @@ func CheckoutBranchForJob(job *schema.Job) error {
 		Create: !branchExists,
 	})
 	if err != nil {
-		return fmt.Errorf("Error checking out chore branch: %w", err)
+		return fmt.Errorf("error checking out chore branch: %w", err)
 	}
-
-	reportRepoState(realRepo, "chore branch: after checkout")
 
 	return nil
 }
 
-func CommitAndPushIfChanged(job *schema.Job, profile *schema.PlatformProfile) (bool, error) {
-	realRepo, worktree, err := openRepo(job.Repo)
+func CommitIfChanged(job *schema.Job, profile *schema.PlatformProfile) (bool, error) {
+	_, worktree, err := openRepo(job.Repo)
 	if err != nil {
 		return false, err
 	}
@@ -114,13 +97,10 @@ func CommitAndPushIfChanged(job *schema.Job, profile *schema.PlatformProfile) (b
 	}
 
 	if repoStatus.IsClean() {
-		l.Info("Chore did not modify repo")
 		return false, nil
 	}
 
-	l.Info("Committing and pushing changes")
-
-	reportRepoState(realRepo, "commit: before")
+	l.Info("Committing changes")
 
 	_, err = worktree.Add(".")
 	if err != nil {
@@ -139,17 +119,61 @@ func CommitAndPushIfChanged(job *schema.Job, profile *schema.PlatformProfile) (b
 		return false, fmt.Errorf("Error committing changes: %w", err)
 	}
 
-	reportRepoState(realRepo, "commit: after")
+	return true, nil
+}
 
-	err = realRepo.Push(&git.PushOptions{
-		Force: false,
-		Auth:  job.Repo.Auth.ToTransportAuth(),
-	})
+func TmpBranchHasChanges(job *schema.Job) (bool, error) {
+	realRepo, _, err := openRepo(job.Repo)
 	if err != nil {
-		return false, fmt.Errorf("Error pushing changes: %w", err)
+		return false, err
 	}
 
-	return true, nil
+	finalBranchExists, err := branchExists(realRepo, job.FinalBranchName)
+	if err != nil {
+		return false, fmt.Errorf("error checking whether final branch exists: %w", err)
+	}
+
+	if !finalBranchExists {
+		// final branch doesn't exist yet, so we definitely need to push changes
+		return true, nil
+	}
+
+	// final branch does exist, so check whether it's different to the temp branch
+	tmpBranchCommit, err := getLatestCommit(realRepo, job.TmpBranchName)
+	if err != nil {
+		return false, fmt.Errorf("error getting latest commit on temporary branch: %w", err)
+	}
+
+	finalBranchCommit, err := getLatestCommit(realRepo, job.FinalBranchName)
+	if err != nil {
+		return false, fmt.Errorf("error getting latest commit on final branch: %w", err)
+	}
+
+	hasChanges := tmpBranchCommit.TreeHash != finalBranchCommit.TreeHash
+
+	return hasChanges, nil
+}
+
+func Push(job *schema.Job) error {
+	realRepo, _, err := openRepo(job.Repo)
+	if err != nil {
+		return err
+	}
+
+	l.Info("Pushing changes")
+
+	err = realRepo.Push(&git.PushOptions{
+		RefSpecs: []config.RefSpec{
+			config.RefSpec(plumbing.ReferenceName("refs/heads/"+job.TmpBranchName) + ":" + plumbing.ReferenceName("refs/heads/"+job.FinalBranchName)),
+		},
+		Auth:  job.Repo.Auth.ToTransportAuth(),
+		Force: true,
+	})
+	if err != nil {
+		return fmt.Errorf("error pushing changes: %w", err)
+	}
+
+	return nil
 }
 
 func openRepo(r *schema.Repo) (*git.Repository, *git.Worktree, error) {
@@ -189,12 +213,36 @@ func fetchAll(repo *schema.Repo) error {
 	return nil
 }
 
-func reportRepoState(realRepo *git.Repository, note string) {
-	head, err := realRepo.Head()
+func branchExists(realRepo *git.Repository, branchName string) (bool, error) {
+	branchRefName := plumbing.NewBranchReferenceName(branchName)
+	branchExists := false
+	branches, err := realRepo.Branches()
 	if err != nil {
-		l.Error("Failed to repo repo state", "error", err)
-		return
+		return false, fmt.Errorf("error listing repo branches: %w", err)
+	}
+	err = branches.ForEach(func(ref *plumbing.Reference) error {
+		if ref.Name() == branchRefName {
+			branchExists = true
+		}
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("error iterating branches: %w", err)
 	}
 
-	l.Debug("Repo state @ "+note, "headName", head.Name(), "headHash", head.Hash().String())
+	return branchExists, nil
+}
+
+func getLatestCommit(realRepo *git.Repository, branchName string) (*object.Commit, error) {
+	branchRef, err := realRepo.Reference(plumbing.ReferenceName("refs/heads/"+branchName), true)
+	if err != nil {
+		return nil, fmt.Errorf("error getting branch reference: %w", err)
+	}
+
+	commit, err := realRepo.CommitObject(branchRef.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("error getting latest commit: %w", err)
+	}
+
+	return commit, nil
 }

--- a/internal/schema/executors.go
+++ b/internal/schema/executors.go
@@ -51,7 +51,7 @@ type Job struct {
 	Chore           *ChoreSpec
 	ExecutionSteps  []ExecutionStep
 	PlatformConfig  *PlatformConfig
-	TmpBranchName   string
+	WorkBranchName  string
 	FinalBranchName string
 }
 

--- a/internal/schema/executors.go
+++ b/internal/schema/executors.go
@@ -45,12 +45,14 @@ type ExecutionStep struct {
 
 // Job represents an item of work to be done: a specific chore on a specific repo. It should be self-contained; i.e. carry all the info needed to perform a job.
 type Job struct {
-	Config         *TediumConfig
-	Repo           *Repo
-	RepoConfig     *ResolvedRepoConfig
-	Chore          *ChoreSpec
-	ExecutionSteps []ExecutionStep
-	PlatformConfig *PlatformConfig
+	Config          *TediumConfig
+	Repo            *Repo
+	RepoConfig      *ResolvedRepoConfig
+	Chore           *ChoreSpec
+	ExecutionSteps  []ExecutionStep
+	PlatformConfig  *PlatformConfig
+	TmpBranchName   string
+	FinalBranchName string
 }
 
 // ToEnvironment() generates a set of environment variables that are passed into chore execution steps.


### PR DESCRIPTION
When chores are run for the 2nd+ time, previously they would execute on the existing chore branch. This meant that if a previous version of a chore left the repo in a broken state, re-running the chore after fixing it might not be able to fix the repo.

This PR changes that so that chores always run against the repo state on the default branch, blind to any changes made by previous runs of the chore. If any changes made haven't been pushed before, or differ from what is already pushed, they are force-pushed to the chore branch.

Closes #50.