### PR TITLE
improve chore environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ chores:
     # Optional.
     branch: "my-experimental-change"
 
+    # Expose the platform's auth token to chore steps via the TEDIUM_PLATFORM_TOKEN environment variable. Use with caution.
+    # Optional, defaults to false.
+    exposePlatformToken: true
+
     # Additional environment variables to pass to every step of the chore. Must not start with "TEDIUM_".
     # Optional.
     environment:

--- a/internal/entrypoints/config.go
+++ b/internal/entrypoints/config.go
@@ -88,9 +88,10 @@ func resolveRepoConfig(conf *schema.TediumConfig, targetRepo *schema.Repo) (*sch
 		Chores: make([]*schema.ChoreSpec, len(mergedConfig.Chores)),
 	}
 	for choreIdx := range mergedConfig.Chores {
-		choreRepoUrl := mergedConfig.Chores[choreIdx].Url
-		choreBranch := mergedConfig.Chores[choreIdx].Branch
-		choreDirectory := mergedConfig.Chores[choreIdx].Directory
+		sourceChore := &mergedConfig.Chores[choreIdx]
+		choreRepoUrl := sourceChore.Url
+		choreBranch := sourceChore.Branch
+		choreDirectory := sourceChore.Directory
 
 		choreRepo, err := schema.RepoFromUrl(choreRepoUrl)
 		if err != nil {
@@ -118,6 +119,8 @@ func resolveRepoConfig(conf *schema.TediumConfig, targetRepo *schema.Repo) (*sch
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal chore config file: %w", err)
 		}
+
+		choreSpec.SourceConfig = sourceChore
 
 		resolvedConfig.Chores[choreIdx] = &choreSpec
 	}

--- a/internal/entrypoints/run.go
+++ b/internal/entrypoints/run.go
@@ -41,7 +41,14 @@ func Run(conf *schema.TediumConfig) {
 			break
 		}
 
-		err = executors.PrepareJob(job)
+		platform, err := platforms.FromConfig(conf, job.PlatformConfig)
+		if err != nil {
+			l.Error("Failed to get platform for job - aborting this chore", "error", err, "repo", job.Repo.FullName(), "chore", job.Chore.Name)
+			// TODO: count - did some chores fail?
+			continue
+		}
+
+		err = executors.PrepareJob(platform, job)
 		if err != nil {
 			l.Error("Failed to prepare job - aborting this chore", "error", err, "repo", job.Repo.FullName(), "chore", job.Chore.Name)
 			// TODO: count - did some chores fail?
@@ -145,7 +152,6 @@ func gatherJobs(conf *schema.TediumConfig) *utils.Queue[schema.Job] {
 				jobQueue.Push(schema.Job{
 					Config:          conf,
 					Repo:            targetRepo,
-					RepoConfig:      repoConfig,
 					Chore:           chore,
 					PlatformConfig:  platformConfig,
 					WorkBranchName:  utils.UniqueName("work"),

--- a/internal/executors/executor.go
+++ b/internal/executors/executor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/markormesher/tedium/internal/executors/kubernetes"
 	"github.com/markormesher/tedium/internal/executors/podman"
 	"github.com/markormesher/tedium/internal/logging"
+	"github.com/markormesher/tedium/internal/platforms"
 	"github.com/markormesher/tedium/internal/schema"
 )
 
@@ -24,57 +25,70 @@ func FromExecutorConfig(ec *schema.ExecutorConfig) (schema.Executor, error) {
 	return nil, fmt.Errorf("No executor specified")
 }
 
-func PrepareJob(job *schema.Job) error {
+func PrepareJob(platform platforms.Platform, job *schema.Job) error {
 	tediumImage := job.Config.Images.Tedium
 
 	// add our own steps to the chore (editing in place)
 
+	jobEnvBundle, err := job.ToEnvironment()
+	if err != nil {
+		return fmt.Errorf("Error generating environment variables for job: %w", err)
+	}
+
 	if !job.Chore.SkipCloneStep {
 		tediumStep := schema.ChoreStep{
-			Image:   tediumImage,
-			Command: "/app/tedium --internal-command initChore",
+			Image:       tediumImage,
+			Command:     "/app/tedium --internal-command initChore",
+			Environment: jobEnvBundle,
+			Internal:    true,
 		}
 		job.Chore.Steps = append([]schema.ChoreStep{tediumStep}, job.Chore.Steps...)
 	}
 
 	if !job.Chore.SkipFinaliseStep {
 		tediumStep := schema.ChoreStep{
-			Image:   tediumImage,
-			Command: "/app/tedium --internal-command finaliseChore",
+			Image:       tediumImage,
+			Command:     "/app/tedium --internal-command finaliseChore",
+			Environment: jobEnvBundle,
+			Internal:    true,
 		}
 		job.Chore.Steps = append(job.Chore.Steps, tediumStep)
 	}
 
 	// convert chore steps into execution steps
 
-	baseEnv, err := job.ToEnvironment()
-	if err != nil {
-		return fmt.Errorf("Error generating environment variables for job: %w", err)
-	}
-
 	job.ExecutionSteps = make([]schema.ExecutionStep, len(job.Chore.Steps))
 	for i := range job.Chore.Steps {
-		step := job.Chore.Steps[i]
+		step := &job.Chore.Steps[i]
 		job.ExecutionSteps[i] = schema.ExecutionStep{
 			Label:       fmt.Sprintf("step-%d", i+1),
 			Image:       step.Image,
 			Command:     step.Command,
-			Environment: envForStep(baseEnv, job.Chore, &step),
+			Environment: envForStep(platform, job, step),
 		}
 	}
 
 	return nil
 }
 
-func envForStep(baseEnv map[string]string, chore *schema.ChoreSpec, step *schema.ChoreStep) map[string]string {
+func envForStep(platform platforms.Platform, job *schema.Job, step *schema.ChoreStep) map[string]string {
 	env := make(map[string]string)
-	for k, v := range baseEnv {
-		env[k] = v
-	}
 
 	env["TEDIUM_COMMAND"] = step.Command
+	env["TEDIUM_REPO_OWNER"] = job.Repo.OwnerName
+	env["TEDIUM_REPO_NAME"] = job.Repo.Name
+	env["TEDIUM_REPO_DEFAULT_BRANCH"] = job.Repo.DefaultBranch
+	env["GIT_COMMITTER_EMAIL"] = platform.Profile().Email
 
 	for k, v := range step.Environment {
+		if !step.Internal && strings.HasPrefix(k, "TEDIUM_") {
+			l.Warn("Not passing environment variable to chore step", "key", k)
+		} else {
+			env[k] = v
+		}
+	}
+
+	for k, v := range job.Chore.SourceConfig.Environment {
 		if strings.HasPrefix(k, "TEDIUM_") {
 			l.Warn("Not passing environment variable to chore step", "key", k)
 		} else {
@@ -82,12 +96,8 @@ func envForStep(baseEnv map[string]string, chore *schema.ChoreSpec, step *schema
 		}
 	}
 
-	for k, v := range chore.UserProvidedEnvironment {
-		if strings.HasPrefix(k, "TEDIUM_") {
-			l.Warn("Not passing environment variable to chore step", "key", k)
-		} else {
-			env[k] = v
-		}
+	if job.Chore.SourceConfig.ExposePlatformToken {
+		env["TEDIUM_PLATFORM_TOKEN"] = platform.AuthToken()
 	}
 
 	return env

--- a/internal/executors/executor.go
+++ b/internal/executors/executor.go
@@ -32,7 +32,7 @@ func PrepareJob(platform platforms.Platform, job *schema.Job) error {
 
 	jobEnvBundle, err := job.ToEnvironment()
 	if err != nil {
-		return fmt.Errorf("Error generating environment variables for job: %w", err)
+		return fmt.Errorf("error generating job environment variable: %w", err)
 	}
 
 	if !job.Chore.SkipCloneStep {

--- a/internal/executors/executor.go
+++ b/internal/executors/executor.go
@@ -74,11 +74,17 @@ func PrepareJob(platform platforms.Platform, job *schema.Job) error {
 func envForStep(platform platforms.Platform, job *schema.Job, step *schema.ChoreStep) map[string]string {
 	env := make(map[string]string)
 
+	// used by Tedium directly
 	env["TEDIUM_COMMAND"] = step.Command
+
+	// not used by Tedium directly
 	env["TEDIUM_REPO_OWNER"] = job.Repo.OwnerName
 	env["TEDIUM_REPO_NAME"] = job.Repo.Name
 	env["TEDIUM_REPO_DEFAULT_BRANCH"] = job.Repo.DefaultBranch
-	env["GIT_COMMITTER_EMAIL"] = platform.Profile().Email
+	env["TEDIUM_PLATFORM_EMAIL"] = platform.Profile().Email
+	if job.Chore.SourceConfig.ExposePlatformToken {
+		env["TEDIUM_PLATFORM_TOKEN"] = platform.AuthToken()
+	}
 
 	for k, v := range step.Environment {
 		if !step.Internal && strings.HasPrefix(k, "TEDIUM_") {
@@ -94,10 +100,6 @@ func envForStep(platform platforms.Platform, job *schema.Job, step *schema.Chore
 		} else {
 			env[k] = v
 		}
-	}
-
-	if job.Chore.SourceConfig.ExposePlatformToken {
-		env["TEDIUM_PLATFORM_TOKEN"] = platform.AuthToken()
 	}
 
 	return env

--- a/internal/platforms/gitea.go
+++ b/internal/platforms/gitea.go
@@ -56,6 +56,14 @@ func (p *GiteaPlatform) Profile() *schema.PlatformProfile {
 	return p.profile
 }
 
+func (p *GiteaPlatform) AuthToken() string {
+	if p.auth == nil {
+		return ""
+	}
+
+	return p.auth.Token
+}
+
 func (p *GiteaPlatform) DiscoverRepos() ([]schema.Repo, error) {
 	if p.auth == nil {
 		l.Warn("No auth configured for paltform; skipping repo discovery", "domain", p.domain)

--- a/internal/platforms/github.go
+++ b/internal/platforms/github.go
@@ -52,6 +52,23 @@ func (p *GitHubPlatform) Profile() *schema.PlatformProfile {
 	return p.profile
 }
 
+func (p *GitHubPlatform) AuthToken() string {
+	if p.auth == nil {
+		return ""
+	}
+
+	switch p.auth.Type {
+	case schema.AuthConfigTypeUserToken:
+		return p.auth.Token
+
+	case schema.AuthConfigTypeApp:
+		return p.auth.AppInstallationToken
+
+	default:
+		return ""
+	}
+}
+
 func (p *GitHubPlatform) DiscoverRepos() ([]schema.Repo, error) {
 	if p.auth == nil {
 		l.Warn("No auth configured for paltform; skipping repo discovery", "domain", p.domain)

--- a/internal/platforms/platform.go
+++ b/internal/platforms/platform.go
@@ -18,6 +18,7 @@ type Platform interface {
 	AcceptsDomain(string) bool
 
 	Profile() *schema.PlatformProfile
+	AuthToken() string
 
 	DiscoverRepos() ([]schema.Repo, error)
 	RepoHasTediumConfig(repo *schema.Repo) (bool, error)

--- a/internal/schema/chores.go
+++ b/internal/schema/chores.go
@@ -12,13 +12,15 @@ type ChoreSpec struct {
 	SkipCloneStep    bool `json:"skipCloneStep" yaml:"skipCloneStep"`
 	SkipFinaliseStep bool `json:"skipFinaliseStep" yaml:"skipFinaliseStep"`
 
-	UserProvidedEnvironment map[string]string `json:"donotuse_userProvidedEnvironment"`
+	// SourceConfig contains the original user-specified config that was resolved into this chore.
+	SourceConfig *RepoChoreConfig
 }
 
 type ChoreStep struct {
 	Image       string `json:"image" yaml:"image"`
 	Command     string `json:"command" yaml:"command"`
 	Environment map[string]string
+	Internal    bool `json:"-"`
 }
 
 func (choreSpec *ChoreSpec) PrTitle() string {

--- a/internal/schema/config.go
+++ b/internal/schema/config.go
@@ -52,6 +52,9 @@ type RepoChoreConfig struct {
 
 	// Environment specifies additional environment variables to be passed to all stages of chore execution. Variables must not start with "TEDIUM_.
 	Environment map[string]string `json:"environment" yaml:"environment"`
+
+	// ExposePlatformToken specifies that the target repo's platform auth token should be exposed to chore steps via the TEDIUM_PLATFORM_TOKEN environment variable. Use with caution.
+	ExposePlatformToken bool `json:"exposePlatformToken" yaml:"exposePlatformToken"`
 }
 
 // ResolvedRepoConfig is the result of taking a target repo, following all "extends" links, and resolving all chore references into their actual spec.

--- a/internal/schema/executors.go
+++ b/internal/schema/executors.go
@@ -47,7 +47,6 @@ type ExecutionStep struct {
 type Job struct {
 	Config          *TediumConfig
 	Repo            *Repo
-	RepoConfig      *ResolvedRepoConfig
 	Chore           *ChoreSpec
 	ExecutionSteps  []ExecutionStep
 	PlatformConfig  *PlatformConfig
@@ -55,23 +54,16 @@ type Job struct {
 	FinalBranchName string
 }
 
-// ToEnvironment() generates a set of environment variables that are passed into chore execution steps.
+// ToEnvironment() bundles the Job into a single environment variable that can be unpacked later by the init and finalise stages of an execution.
 func (job *Job) ToEnvironment() (map[string]string, error) {
-	env := make(map[string]string, 0)
-
-	// used directly by Tedium for the init and finalise steps
 	jobStrBytes, err := json.Marshal(job)
 	if err != nil {
 		return nil, fmt.Errorf("Error marshalling Tedium config into environment variable: %w", err)
 	}
-	env["TEDIUM_JOB"] = string(jobStrBytes)
 
-	// made available for convenience in actual chore steps
-	env["TEDIUM_REPO_OWNER"] = job.Repo.OwnerName
-	env["TEDIUM_REPO_NAME"] = job.Repo.Name
-	// ...more
-
-	return env, nil
+	return map[string]string{
+		"TEDIUM_JOB": string(jobStrBytes),
+	}, nil
 }
 
 func JobFromEnvironment() (*Job, error) {


### PR DESCRIPTION
- don't expose the full TEDIUM_JOB environment to steps that we don't control
- allow *users* (not chores) to opt-in to providing the auth token to chores
- don't ignore user-provided environment
- set more convenience env values